### PR TITLE
feat: add ProteomeScan parse_results primitive

### DIFF
--- a/deepchem_server/core/primitives/compute.py
+++ b/deepchem_server/core/primitives/compute.py
@@ -15,7 +15,10 @@ from deepchem_server.core.primitives.partition import partition
 from deepchem_server.core.primitives.pdb_clean import pdb_clean
 from deepchem_server.core.primitives.splitter import train_valid_test_split
 from deepchem_server.core.primitives.train import train
-from deepchem_server.core.primitives.proteome_scan.docking import run_docking
+from deepchem_server.core.primitives.proteome_scan import (
+    parse_results,
+    run_docking,
+)
 
 
 program_map = {
@@ -33,6 +36,7 @@ program_map = {
     "collate_rbfe_results": collate_rbfe_results,
     "del_denoise": del_denoise,
     "run_docking": run_docking,
+    "parse_results": parse_results,
 }
 
 

--- a/deepchem_server/core/primitives/proteome_scan/__init__.py
+++ b/deepchem_server/core/primitives/proteome_scan/__init__.py
@@ -6,9 +6,11 @@ Primitives used to run the proteome scan workflow in deepchem-server.
 
 from deepchem_server.core.primitives.proteome_scan import cache  # noqa: F401
 from deepchem_server.core.primitives.proteome_scan.docking import run_docking
+from deepchem_server.core.primitives.proteome_scan.parse_results import parse_results
 
 
 __all__ = [
     "cache",
+    "parse_results",
     "run_docking",
 ]

--- a/deepchem_server/core/primitives/proteome_scan/parse_results.py
+++ b/deepchem_server/core/primitives/proteome_scan/parse_results.py
@@ -1,0 +1,136 @@
+"""
+Combine per-gene docking results into per-ligand summary tables.
+"""
+
+import json
+import os
+from typing import Dict, List
+
+import pandas as pd
+
+from deepchem_server.core.common import config
+from deepchem_server.core.common.cards import DataCard
+from deepchem_server.core.common.progress_logger import log_progress
+from deepchem_server.core.primitives.proteome_scan import cache as ps_cache
+
+
+def _concat_csv_from_folder(folder_path: str) -> pd.DataFrame:
+    """
+    Concatenate all CSV files in a folder into a single DataFrame.
+
+    Parameters
+    ----------
+    folder_path : str
+        Directory containing CSV files.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Concatenated table. If the directory is missing or contains no CSV
+        files, an empty DataFrame is returned.
+
+    Examples
+    --------
+    >>> df = _concat_csv_from_folder("/tmp/does_not_exist")
+    """
+    main_df = pd.DataFrame()
+    if not os.path.isdir(folder_path):
+        return main_df
+    for filename in sorted(os.listdir(folder_path)):
+        file_path = os.path.join(folder_path, filename)
+        if filename.endswith(".csv") and os.path.isfile(file_path):
+            temp_df = pd.read_csv(file_path)
+            main_df = pd.concat([main_df, temp_df], ignore_index=True)
+    return main_df
+
+
+def parse_results(
+    scan_id: str,
+    ligands: List[str],
+    output: str,
+) -> str:
+    """Aggregate docking results and upload per-ligand tables.
+
+    Parameters
+    ----------
+    scan_id: str
+        Scan identifier. Results for each ligand are read from
+        ``<cache_root>/<scan_id>/<ligand>/`` and written to
+        ``<cache_root>/<scan_id>/scan_results/``.
+    ligands: List[str]
+        Ligand names to aggregate. Each must have a corresponding
+        on-disk folder populated by ``run_docking``.
+    output: str
+        Output name prefix for uploaded datastore artifacts.
+
+    Returns
+    -------
+    str
+        DeepChem address of a summary JSON describing the aggregated
+        per-ligand CSVs (address + local path).
+
+    Examples
+    --------
+    >>> addr = parse_results("scan1", ["LIG"], output="my_run")
+    """
+    datastore = config.get_datastore()
+    if datastore is None:
+        raise ValueError("Datastore not set")
+    if not scan_id:
+        raise ValueError("scan_id is required")
+    if not ligands:
+        raise ValueError("ligands is required")
+    if not output:
+        raise ValueError("output is required")
+
+    ps_cache.get_scan_results_dir(scan_id)
+
+    aggregated: Dict[str, Dict[str, object]] = {}
+    n_ligands = len(ligands)
+    for i, ligand in enumerate(ligands):
+        raw_results_folder = str(ps_cache.get_ligand_dir(scan_id, ligand))
+        log_progress(
+            "parse_results", int(5 + 60 * i / max(1, n_ligands)), f"aggregating ligand {ligand}"
+        )
+        df = _concat_csv_from_folder(raw_results_folder)
+        if df.empty:
+            log_progress("parse_results", 0, f"no CSVs found for ligand {ligand}")
+            aggregated[ligand] = {
+                "address": None,
+                "local_path": None,
+                "num_rows": 0,
+            }
+            continue
+        df = df.sort_values(by="top_score")
+        if "gene_name" in df.columns:
+            df = df.drop_duplicates("gene_name", keep="first")
+        df = df.rename(columns={"Unnamed: 0": "pdb_id"})
+
+        out_path = ps_cache.top_score_ligand_csv_path(scan_id, ligand)
+        df.to_csv(out_path, index=False)
+
+        csv_card = DataCard(address="", file_type="csv", data_type="pandas.DataFrame")
+        csv_key = f"{output}_top_score_{ligand}.csv"
+        csv_address = datastore.upload_data_from_memory(df, csv_key, csv_card)
+        aggregated[ligand] = {
+            "address": csv_address,
+            "local_path": str(out_path),
+            "num_rows": int(len(df)),
+        }
+
+    summary = {
+        "scan_id": scan_id,
+        "ligands": ligands,
+        "aggregated": aggregated,
+    }
+    summary_json = json.dumps(summary, indent=2, default=str)
+    json_card = DataCard(address="", file_type="json", data_type="json")
+    summary_address = datastore.upload_data_from_memory(
+        summary_json, f"{output}_parse_results.json", json_card
+    )
+
+    log_progress("parse_results", 100, "parse_results complete")
+    return summary_address
+
+
+__all__ = ["parse_results"]

--- a/deepchem_server/core/tests/proteome_scan/test_parse_results.py
+++ b/deepchem_server/core/tests/proteome_scan/test_parse_results.py
@@ -1,0 +1,117 @@
+"""
+Tests for the proteome_scan.parse_results primitive.
+"""
+
+import json
+from io import StringIO
+
+import pandas as pd
+import pytest
+
+from deepchem_server.core import config
+from deepchem_server.core.primitives.proteome_scan import cache as ps_cache
+from deepchem_server.core.primitives.proteome_scan.parse_results import (
+    parse_results,
+)
+
+
+@pytest.fixture
+def proteome_scan_cache(tmp_path, monkeypatch):
+    cache_root = tmp_path / "proteome_scan_cache"
+    cache_root.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("PROTEOMESCAN_CACHE_ROOT", str(cache_root))
+    return cache_root
+
+
+class TestParseResults:
+    def test_parse_results_aggregates_and_sorts(self, disk_datastore, proteome_scan_cache):
+        """parse_results must concat per-gene CSVs, sort by top_score
+        and dedupe by gene_name."""
+        config.set_datastore(disk_datastore)
+
+        scan_id = "scan_parse"
+        ligand = "LIG"
+        ligand_dir = ps_cache.get_ligand_dir(scan_id, ligand)
+
+        df1 = pd.DataFrame(
+            {
+                "": ["1ABC", "1XYZ"],
+                "chains": ["A=1-100", "A=1-100"],
+                "resolution": [1.5, 1.8],
+                "coverage": [99, 99],
+                "top_score": [-9.2, -7.5],
+                "scores": [[-9.2], [-7.5]],
+                "gene_name": ["GENE1", "GENE1"],
+            }
+        )
+        df1.to_csv(str(ligand_dir / f"top_score_GENE1_{ligand}.csv"), index=False)
+
+        df2 = pd.DataFrame(
+            {
+                "": ["2DEF"],
+                "chains": ["A=1-200"],
+                "resolution": [1.2],
+                "coverage": [199],
+                "top_score": [-8.5],
+                "scores": [[-8.5]],
+                "gene_name": ["GENE2"],
+            }
+        )
+        df2.to_csv(str(ligand_dir / f"top_score_GENE2_{ligand}.csv"), index=False)
+
+        summary_addr = parse_results(
+            scan_id=scan_id,
+            ligands=[ligand],
+            output="parse_run",
+        )
+
+        assert summary_addr.startswith("deepchem://")
+        summary = disk_datastore.get(summary_addr)
+        if isinstance(summary, str):
+            summary = json.loads(summary)
+
+        assert summary["scan_id"] == scan_id
+        assert ligand in summary["aggregated"]
+        agg = summary["aggregated"][ligand]
+        assert agg["num_rows"] == 2
+
+        out_csv = ps_cache.top_score_ligand_csv_path(scan_id, ligand)
+        assert out_csv.exists()
+        out_df = pd.read_csv(out_csv)
+        assert list(out_df["gene_name"]) == ["GENE1", "GENE2"]
+        assert out_df["top_score"].iloc[0] == -9.2
+
+        csv_addr = agg["address"]
+        reloaded = disk_datastore.get(csv_addr)
+        if isinstance(reloaded, str):
+            reloaded = pd.read_csv(StringIO(reloaded))
+        pd.testing.assert_frame_equal(
+            out_df.reset_index(drop=True),
+            reloaded.reset_index(drop=True),
+            check_dtype=False,
+        )
+
+    def test_parse_results_empty_ligand_folder(self, disk_datastore, proteome_scan_cache):
+        config.set_datastore(disk_datastore)
+        scan_id = "scan_parse_empty"
+        ps_cache.get_ligand_dir(scan_id, "EMPTY")
+
+        summary_addr = parse_results(
+            scan_id=scan_id,
+            ligands=["EMPTY"],
+            output="parse_empty",
+        )
+        summary = disk_datastore.get(summary_addr)
+        if isinstance(summary, str):
+            summary = json.loads(summary)
+        assert summary["aggregated"]["EMPTY"]["num_rows"] == 0
+        assert summary["aggregated"]["EMPTY"]["address"] is None
+
+    def test_parse_results_requires_args(self, disk_datastore, proteome_scan_cache):
+        config.set_datastore(disk_datastore)
+        with pytest.raises(ValueError):
+            parse_results(scan_id="", ligands=["LIG"], output="o")
+        with pytest.raises(ValueError):
+            parse_results(scan_id="s", ligands=[], output="o")
+        with pytest.raises(ValueError):
+            parse_results(scan_id="s", ligands=["L"], output="")

--- a/deepchem_server/routers/primitives.py
+++ b/deepchem_server/routers/primitives.py
@@ -1006,3 +1006,49 @@ async def proteome_scan_docking(
         raise HTTPException(status_code=500, detail=f"run_docking failed: {str(e)}")
 
     return {"results_address": str(result)}
+
+
+@router.post("/proteome-scan/parse-results")
+async def proteome_scan_parse_results(
+    profile_name: Annotated[str, Body()],
+    project_name: Annotated[str, Body()],
+    scan_id: Annotated[str, Body()],
+    ligands: Annotated[List[str], Body()],
+    output: Annotated[str, Body()],
+) -> dict:
+    """
+    Aggregate per-ligand docking results
+
+    Parameters
+    ----------
+    profile_name: str
+        Name of the Profile where the job is run.
+    project_name: str
+        Name of the Project where the job is run.
+    scan_id: str
+        Scan identifier (same ``scan_id`` used for ``pdb_clean``
+        and ``run_docking``).
+    ligands: List[str]
+        Ligand names whose per-gene CSVs should be aggregated.
+    output: str
+        Output name prefix for uploaded datastore artifacts.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``results_address`` - the datastore
+        address of the aggregation summary JSON.
+    """
+    program = {
+        "program_name": "parse_results",
+        "scan_id": scan_id,
+        "ligands": ligands,
+        "output": output,
+    }
+
+    try:
+        result = run_job(profile_name=profile_name, project_name=project_name, program=program)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"parse_results failed: {str(e)}")
+
+    return {"results_address": str(result)}


### PR DESCRIPTION
## Summary

- Adds `parse_results` primitive that aggregates per-gene docking result CSVs into a sorted, deduplicated per-ligand summary table
- Wires `parse_results` into `compute.py` program_map
- Exposes `/primitive/proteome-scan/parse-results` FastAPI endpoint

## Dependencies

Requires `feat-proteome-scan-docking-cache` (provides `proteome_scan.cache`).

## Test plan

- [ ] `pytest deepchem_server/core/tests/proteome_scan/test_parse_results.py`